### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,13 @@ project(Auto3dgm)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://toothandclaw.github.io")
 set(EXTENSION_CATEGORY "Auto3dgm")
-set(EXTENSION_CONTRIBUTORS "Doug Boyer (Duke University)")
+set(EXTENSION_CONTRIBUTORS "Doug M. Boyer (Duke University)")
 set(EXTENSION_DESCRIPTION "Auto3dgm allows for comparative analysis of 3D digital models representing biological surfaces. Unlike other three-dimensional geometric morphometric (3DGM) methods this software uses a fully automated procedure for placing landmarks on the surfaces. This allows for the alignment of surfaces followed by measuring distance between surfaces with minimal user intervention.
+
 The goal of this NSF funded project is to extend Auto3dgm to open source software platform and make it more user-friendly to a larger scientific community. Towards this goal, we developed the Auto3dgm module in 3D Slicer, an open source software platform for medical image informatics, image processing, and three-dimensional visualization. The module enables scientists to perform Auto3dgm on a collection of shapes effectively within 3D Slicer. The package also alllows users to visualize and save the aligned results to local machines for downstream analysis.
+
 This project is supported by a NSF Advances in Biological Informatics Collaborative grant to Murat Maga (ABI-1759883), Adam Summers (ABI-1759637) and Doug Boyer (ABI-1759839).")
-set(EXTENSION_ICONURL "https://raw.githubusercontent.com/ToothAndClaw/SlicerAuto3dgm/master/Auto3dgmLogo.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/ToothAndClaw/SlicerAuto3dgm/master/Auto3dgmLogoSmall.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/ToothAndClaw/SlicerAuto3dgm/master/Auto3dgmScreenshot.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated string, a list or 'NA' if any
 


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.